### PR TITLE
fix: update banner to use register function

### DIFF
--- a/scripts/banner.py
+++ b/scripts/banner.py
@@ -29,7 +29,7 @@ print("""
 |  🚀 Phoenix Server 🚀
 |  Phoenix UI: https://{auth}@{endpoint}
 |  
-|  Instrument your code with environment variables set to
-|  PHOENIX_COLLECTOR_ENDPOINT=https://{auth}@{endpoint}
-|  COLLECTOR_ENDPOINT=https://{auth}@{endpoint}/v1/traces
+|  Instrument your code with:
+|  from phoenix.otel import register
+|  register(endpoint="https://{auth}@{endpoint}/v1/traces")
 """.format(auth=values['SECRET'][0:32]+":"+values['SECRET'][32:], endpoint=values['SERVICE_APP_URI'][8:]))


### PR DESCRIPTION
The current recommended approach in the banner text throws an error when someone tries to use the new register function that we've switched to in all Phoenix examples. The register function doesn't properly infer that the url in the PHOENIX_COLLECTOR_ENDPOINT is an HTTP endpoint, and tries to use GRPC instead, even if you change it to include v1/traces at the end. Seems to be a bug on register, but this fix also aligns this project with our other phoenix examples, so is good to make regardless